### PR TITLE
Update metadata for everything we see in current import

### DIFF
--- a/clinicaltrials/frontend/management/commands/process_data.py
+++ b/clinicaltrials/frontend/management/commands/process_data.py
@@ -27,6 +27,13 @@ logger = logging.getLogger(__name__)
 EARLIEST_CANCELLATION_DATE = date(2018, 7, 5)
 
 def set_qa_metadata(trial):
+    """Scrape `Results Submitted` tab on website for interim reporting
+    (this means results have been submitted at some point, and are
+    under QA).
+
+    Store this data in a TrialQA table
+
+    """
     registry_id = trial.registry_id
     url = "https://clinicaltrials.gov/ct2/show/results/{}".format(registry_id)
     content = html.fromstring(requests.get(url).text)
@@ -61,8 +68,8 @@ def set_qa_metadata(trial):
                     qa, _ = TrialQA.objects.get_or_create(
                         submitted_to_regulator=submitted_date,
                         trial=trial)
-                    qa.cancelled_by_sponsor=cancelled_date
-                    qa.cancellation_date_inferred=cancellation_date_inferred
+                    qa.cancelled_by_sponsor = cancelled_date
+                    qa.cancellation_date_inferred = cancellation_date_inferred
                     qa.save()
 
                 # Take the date on the last line, to cater for cases
@@ -195,6 +202,7 @@ class Command(BaseCommand):
                     'is_pact': truthy(row['included_pact_flag']),
                     'sponsor_id': sponsor.pk,
                     'start_date': row['start_date'],
+                    'updated_date': today,
                     'reported_date': row['results_submitted_date'] or None,
                 }
                 if row['available_completion_date']:
@@ -202,17 +210,10 @@ class Command(BaseCommand):
                 trial_set = Trial.objects.filter(registry_id=row['nct_id'])
                 trial = trial_set.first()
                 if trial:
-                    d['updated_date'] = today
                     trial_set.update(**d)
                 else:
                     d['first_seen_date'] = today
                     Trial.objects.create(**d)
-
-        # Mark zombie trials
-        zombies = Trial.objects.filter(updated_date__lt=today)
-        logger.info("Marking %s zombie trials", zombies.count())
-        zombies.update(
-            status=Trial.STATUS_NO_LONGER_ACT)
 
         # Now scrape trials that might be in QA (these would be
         # flagged as having no results, but if in QA we consider
@@ -222,11 +223,19 @@ class Command(BaseCommand):
         for trial in possible_results:
             set_qa_metadata(trial)
 
-        # Next, compute days_late and status for each trial
-        needs_metadata = Trial.objects.exclude(status=Trial.STATUS_NO_LONGER_ACT)
+        # Next, compute days_late and status for each trial that we
+        # currently consider a pACT/ACT
+        needs_metadata = Trial.objects.filter(updated_date=today)
         logger.info("Computing metadata for %s trials", needs_metadata.count())
         for trial in needs_metadata:
             trial.compute_metadata()
+
+        # Update the status of trials that no longer appear in the dataset
+        zombies = Trial.objects.filter(
+            updated_date__lt=today).exclude(status=Trial.STATUS_NO_LONGER_ACT)
+        logger.info("Marking %s zombie trials", zombies.count())
+        zombies.update(
+            status=Trial.STATUS_NO_LONGER_ACT, updated_date=today)
 
         # This should only happen after Trial statuses have been set
         logger.info("Setting current rankings")

--- a/clinicaltrials/frontend/tests/common.py
+++ b/clinicaltrials/frontend/tests/common.py
@@ -23,7 +23,8 @@ def makeTrial(sponsor, **kw):
         trial = trial.first()
     else:
         trial = Trial.objects.create(**defaults)
-    trial.compute_metadata()
+    if trial.status != Trial.STATUS_NO_LONGER_ACT:
+        trial.compute_metadata()
     trial.refresh_from_db()
     return trial
 

--- a/clinicaltrials/frontend/tests/test_import.py
+++ b/clinicaltrials/frontend/tests/test_import.py
@@ -1,4 +1,5 @@
 from datetime import date
+from datetime import timedelta
 from unittest import mock
 import os
 
@@ -36,11 +37,16 @@ def ccgov_results_by_url(url):
 
 
 class CommandsTestCase(TestCase):
+    def setUp(self):
+        self.today = date(2018, 1, 1)
+        self.yesterday = self.today - timedelta(days=1)
+        self.last_year = self.today - timedelta(days=366)
+
     @mock.patch('requests.get', mock.Mock(side_effect=ccgov_results_by_url))
     @mock.patch('frontend.trial_computer.date')
     def test_import(self, datetime_mock):
         "Does a simple import create expected rankings and sponsors?"
-        datetime_mock.today = mock.Mock(return_value=date(2018,1,1))
+        datetime_mock.today = mock.Mock(return_value=self.today)
 
         args = []
         sample_csv = os.path.join(settings.BASE_DIR, 'frontend/tests/fixtures/sample_bq.csv')
@@ -86,8 +92,8 @@ class CommandsTestCase(TestCase):
         """Does importing the same data twice on subsequent days affect
         individual trials as expected?
         """
-        mock_date_1.today = mock.Mock(return_value=date(2018,1,1))
-        mock_date_2.today = mock.Mock(return_value=date(2018,1,1))
+        mock_date_1.today = mock.Mock(return_value=self.today)
+        mock_date_2.today = mock.Mock(return_value=self.today)
 
         args = []
         sample_csv = os.path.join(settings.BASE_DIR, 'frontend/tests/fixtures/sample_bq.csv')
@@ -101,23 +107,24 @@ class CommandsTestCase(TestCase):
         Trial.objects.all().update(updated_date=date(2017,1,1))
 
         # Import again
-        mock_date_1.today = mock.Mock(return_value=date(2018,1,2))
-        mock_date_2.today = mock.Mock(return_value=date(2018,1,2))
+        tomorrow = self.today + timedelta(days=1)
+        mock_date_1.today = mock.Mock(return_value=tomorrow)
+        mock_date_2.today = mock.Mock(return_value=tomorrow)
         call_command('process_data', *args, **opts)
 
         overdue = Trial.objects.get(registry_id='overdue')
         self.assertEqual(overdue.status, 'overdue')
         self.assertEqual(overdue.days_late, 62)
 
-        self.assertEqual(overdue.updated_date, date(2018,1,2))
-        self.assertEqual(overdue.first_seen_date, date(2018,1,1))
+        self.assertEqual(overdue.updated_date, tomorrow)
+        self.assertEqual(overdue.first_seen_date, self.today)
 
     @mock.patch('requests.get', mock.Mock(side_effect=ccgov_results_by_url))
     @mock.patch('frontend.models.date')
     def test_second_import_with_disappeared_trials(self, datetime_mock):
         """Is the disappearance of a trial from the CSV reflected in our
         database?"""
-        datetime_mock.today = mock.Mock(return_value=date(2018,1,1))
+        datetime_mock.today = mock.Mock(return_value=self.today)
 
         args = []
         sample_csv = os.path.join(settings.BASE_DIR, 'frontend/tests/fixtures/sample_bq.csv')
@@ -125,7 +132,7 @@ class CommandsTestCase(TestCase):
         call_command('process_data', *args, **opts)
 
         # Pretend the previous import took place ages ago
-        Trial.objects.all().update(updated_date=date(2017,1,1))
+        Trial.objects.all().update(updated_date=self.last_year)
 
         # Import empty file
         sample_csv = os.path.join(settings.BASE_DIR, 'frontend/tests/fixtures/sample_bq_empty.csv')
@@ -136,12 +143,39 @@ class CommandsTestCase(TestCase):
         self.assertEqual(Trial.objects.count(), 6)
         self.assertEqual(Trial.objects.visible().count(), 0)
 
+    @mock.patch('requests.get', mock.Mock(side_effect=ccgov_results_by_url))
+    @mock.patch('frontend.models.date')
+    def test_third_import_with_reappearing_trials(self, datetime_mock):
+        """Is the disappearance of a trial from the CSV reflected in our
+        database?"""
+        datetime_mock.today = mock.Mock(return_value=self.today)
+
+        # First import
+        sample_csv = os.path.join(settings.BASE_DIR, 'frontend/tests/fixtures/sample_bq.csv')
+        call_command('process_data', input_csv=sample_csv)
+        # Pretend that import above took place ages ago
+        Trial.objects.all().update(updated_date=self.last_year)
+        overdue = Trial.objects.get(registry_id='overdue')
+        self.assertEqual(overdue.status, 'overdue')
+
+        # Second import: empty file (i.e. everything's gone no-longer-pact)
+        sample_csv = os.path.join(settings.BASE_DIR, 'frontend/tests/fixtures/sample_bq_empty.csv')
+        call_command('process_data', input_csv=sample_csv)
+        Trial.objects.all().update(updated_date=self.yesterday)
+
+        # Third import: everything's become a pACT again
+        sample_csv = os.path.join(settings.BASE_DIR, 'frontend/tests/fixtures/sample_bq.csv')
+        call_command('process_data', input_csv=sample_csv)
+
+        overdue = Trial.objects.get(registry_id='overdue')
+        self.assertEqual(overdue.status, 'overdue')
+        self.assertEqual(overdue.previous_status, 'no-longer-act')
 
     @mock.patch('requests.get', mock.Mock(side_effect=ccgov_results_by_url))
     @mock.patch('frontend.trial_computer.date')
     def test_qa(self, datetime_mock):
         "Does a simple import create expected rankings and sponsors?"
-        datetime_mock.today = mock.Mock(return_value=date(2018,1,1))
+        datetime_mock.today = mock.Mock(return_value=self.today)
 
         args = []
         sample_csv = os.path.join(settings.BASE_DIR, 'frontend/tests/fixtures/sample_bq_qa.csv')
@@ -212,7 +246,7 @@ class CommandsTestCase(TestCase):
     @mock.patch('frontend.trial_computer.date')
     def test_import_twice(self, datetime_mock, requests_mock):
         "Is importing idempotent?"
-        datetime_mock.today = mock.Mock(return_value=date(2018,1,1))
+        datetime_mock.today = mock.Mock(return_value=self.today)
         args = []
         sample_csv = os.path.join(settings.BASE_DIR, 'frontend/tests/fixtures/two_months_qa.csv')
         opts = {'input_csv': sample_csv}

--- a/clinicaltrials/frontend/tests/test_import.py
+++ b/clinicaltrials/frontend/tests/test_import.py
@@ -141,7 +141,7 @@ class CommandsTestCase(TestCase):
         # There should be no Trials visible
         self.assertEqual(Trial.objects.count(), 6)
         self.assertEqual(Trial.objects.visible().count(), 0)
-        self.assertNotEqual(Trial.objects.first().updated_date, date_in_the_past)
+        self.assertNotEqual(Trial.objects.first().updated_date, self.last_year)
 
     @mock.patch('requests.get', mock.Mock(side_effect=ccgov_results_by_url))
     @mock.patch('frontend.models.date')

--- a/clinicaltrials/frontend/trial_computer.py
+++ b/clinicaltrials/frontend/trial_computer.py
@@ -34,20 +34,18 @@ def compute_metadata(trial):
     """
     # NB order matters; logic in trial status calculations depends on
     # how many days late a trial is.
-
-    if trial.status != type(trial).STATUS_NO_LONGER_ACT:
-        trial.days_late = get_days_late(trial)
-        if trial.days_late:
-            trial.finable_days_late = max([
-                trial.days_late - type(trial).FINES_GRACE_PERIOD,
-                0])
-            if trial.finable_days_late == 0:
-                trial.finable_days_late = None
-        else:
+    trial.days_late = get_days_late(trial)
+    if trial.days_late:
+        trial.finable_days_late = max([
+            trial.days_late - type(trial).FINES_GRACE_PERIOD,
+            0])
+        if trial.finable_days_late == 0:
             trial.finable_days_late = None
-        trial.previous_status = trial.status
-        trial.status = get_status(trial)
-        trial.save()
+    else:
+        trial.finable_days_late = None
+    trial.previous_status = trial.status
+    trial.status = get_status(trial)
+    trial.save()
 
 
 def qa_start_date(trial):


### PR DESCRIPTION
This is because pACTs can stop being pACTs.

Closes #159