### PR TITLE
Fixes has_results issue

### DIFF
--- a/clinicaltrials/frontend/management/commands/load_data.py
+++ b/clinicaltrials/frontend/management/commands/load_data.py
@@ -39,10 +39,15 @@ def postprocessor(path, key, value):
     """
     if key.startswith('#') or key.startswith('@'):
         key = key[1:]
+    if key == 'clinical_results':
+        # Arbitrarily long field that we don't need, see #179
+        value = {'truncated_by_postprocessor': True}
     return key, value
+
 
 def wget_file(target, url):
     subprocess.check_call(["wget", "-q", "-O", target, url])
+
 
 def download_and_extract():
     """Clean up from past runs, then download into a temp location and move the

--- a/clinicaltrials/frontend/view.sql
+++ b/clinicaltrials/frontend/view.sql
@@ -97,7 +97,7 @@ SELECT TRIM(json_EXTRACT(json,
   END AS pending_results,
   TRIM(json_EXTRACT(json,  "$.clinical_study.pending_results"), '"') AS pending_data,    
   CASE
-    WHEN json_EXTRACT(json,  "$.clinical_study.clinical_results") IS NOT NULL THEN 1
+    WHEN JSON_EXTRACT_SCALAR(json,"$.clinical_study.results_first_submitted") IS NOT NULL THEN 1
     ELSE 0
   END AS has_results,
   PARSE_DATE("%B %e, %Y",


### PR DESCRIPTION
Currently the `has_results` field uses the presence of the `clinical_results` section of the JSON to determine if results are available for viewing. This is breaking everything because one trial submitted an enormous results section. We can use the availability of the field `results_first_submitted` instead as this will never appear unless there are results, and it's just a date.

Closes #179 