### PR TITLE
Drop computable Rankings.percentage and provide func

### DIFF
--- a/clinicaltrials/frontend/models.py
+++ b/clinicaltrials/frontend/models.py
@@ -254,15 +254,15 @@ class Ranking(models.Model):
     reported = models.IntegerField()
     reported_late = models.IntegerField()
     reported_on_time = models.IntegerField()
-    percentage = models.IntegerField(null=True)
+
+    @property
+    def percentage(self):
+        if not self.due:
+            return None
+        return round(100.0*self.reported/self.due, 1)
 
     def __str__(self):
         return "{}: {} at {}% on {}".format(self.rank, self.sponsor, self.percentage, self.date)
-
-    def save(self, *args, **kwargs):
-        if self.due:
-            self.percentage = float(self.reported)/self.due * 100
-        super(Ranking, self).save(*args, **kwargs)
 
     class Meta:
         unique_together = ('sponsor', 'date',)


### PR DESCRIPTION
At model instance .save() time, we were calculating the value of one column
using two others.

Since the type of that column is an IntegerField but elsewhere on the site we
round to one digit after decimal, a reader complained about the inconsistency
(really that it was a floor() operation).

Instead, this is the first part of the whole fix, but someone else can
"makemigrations" to discard the db column at leisure.

Closes #184