### PR TITLE
Fixing the QA process

### DIFF
--- a/clinicaltrials/frontend/management/commands/process_data.py
+++ b/clinicaltrials/frontend/management/commands/process_data.py
@@ -38,7 +38,8 @@ def set_qa_metadata(trial):
     url = "https://clinicaltrials.gov/ct2/show/results/{}".format(registry_id)
     content = html.fromstring(requests.get(url).text)
     table = content.xpath("//table[.//th//text()[contains(., 'Submission Cycle')]]")
-    results = content.xpath('//*[@id="results"]/text()')[0].strip()
+    results = content.xpath('//*[@id="results"]/text()')
+    results_text = results and results[0].strip()
     if table:
         for row in table[0].xpath(".//tr"):
             if len(row.xpath(".//td")) == 0:
@@ -95,7 +96,7 @@ def set_qa_metadata(trial):
                 if returned:
                     qa.returned_to_sponsor = returned
                     qa.save()
-    elif not table and results == 'Study Results':
+    elif not table and results_text == 'Study Results':
         # This can happen where a study has published the results, but
         # the data dump doesn't yet reflect this. We assume the state
         # is the same as the last time QA results were checked. See


### PR DESCRIPTION
This is the first step to fix the QA checking process. Eventually we can probably remove this entirely but for now, this will fix it

Tied to #198 

What I've done here is go looking for the text in the "Results" tab. If it says "Study Results" that means that results have been posted. Recently we've been running into an issue where the XMLs have not yet been updated to reflect results being posted, but the live website has results posted. When this code goes looking for the results submitted box, it can't find it and thinks the results disappeared leading to it incorrectly being listed as "overdue."

I've added an xpath and another condition based on that xpath search to the QA function that will check for the posting of results (The tab will always read 'Study Results' in that instance). I don't know exactly what to do next, but basically we just need to tell the function to not do anything with that trial if it finds that condition. By the next data refresh the results will likely be posted and then it won't go through the QA check process anyway and will revert to being identified as reported solely through the `has_results` column