### PR TITLE
Only ever present the current rankings via the API

### DIFF
--- a/clinicaltrials/frontend/custom_rest_views.py
+++ b/clinicaltrials/frontend/custom_rest_views.py
@@ -93,7 +93,11 @@ class CSVNonPagingViewSet(viewsets.ModelViewSet):
 
 
 class RankingViewSet(CSVNonPagingViewSet):
-    queryset = Ranking.objects.select_related('sponsor')
+    def get_queryset(self):
+        # Only show the current date
+        date = Ranking.objects.latest('date').date
+        return Ranking.objects.filter(date=date).select_related('sponsor')
+
     serializer_class = RankingSerializer
     ordering_fields = ['sponsor__name', 'due', 'reported', 'percentage']
     filter_class = RankingFilter

--- a/clinicaltrials/frontend/urls.py
+++ b/clinicaltrials/frontend/urls.py
@@ -21,7 +21,7 @@ from .custom_rest_views import SponsorViewSet
 # Routers provide an easy way of automatically determining the URL conf.
 router = routers.DefaultRouter()
 router.register(r'trials', TrialViewSet, base_name='trials')
-router.register(r'rankings', RankingViewSet)
+router.register(r'rankings', RankingViewSet, base_name='rankings')
 router.register(r'sponsors', SponsorViewSet)
 
 class StaticViewSitemap(Sitemap):

--- a/clinicaltrials/static/js/site.js
+++ b/clinicaltrials/static/js/site.js
@@ -121,10 +121,9 @@ function showPerformance(sponsorSlug) {
   });
 }
 
-function rankingTable(latestDate) {
+function rankingTable() {
   var url = '/api/rankings/?limit=5000';
   var params = getRankingParams();
-  params['date'] = latestDate;
   params['due__gte'] = 1;
   setFormValues(params);
   var table = $('#sponsor_table').DataTable( {

--- a/clinicaltrials/templates/rankings.html
+++ b/clinicaltrials/templates/rankings.html
@@ -68,7 +68,7 @@
 {% block extra_js %}
   <script>
   $(document).ready(function() {
-    rankingTable('{{ LATEST_DATE|date:"Y-m-d" }}');
+    rankingTable();
     $('#results').fadeTo(500, 1);
     showPerformance();
     });


### PR DESCRIPTION
This is the only thing end users should care about, and exposing
everything means expensive paging can result when the API is crawled.

Closes #213