### PR TITLE
Use compat Plausible Analytics code

### DIFF
--- a/clinicaltrials/templates/_base.html
+++ b/clinicaltrials/templates/_base.html
@@ -30,7 +30,7 @@
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.10.16/fh-3.1.3/datatables.min.css"/>
     <!--  Fonts and icons     -->
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/latest/css/font-awesome.min.css" rel="stylesheet">
-    <script async defer data-domain="fdaaa.trialstracker.net" src="https://plausible.io/js/plausible.js"></script>
+    <script id="plausible" defer data-domain="fdaaa.trialstracker.net" src="https://plausible.io/js/plausible.compat.js"></script>
 </head>
 <body>
 <a target="_new" href="http://www.alltrials.net/find-out-more/why-this-matters/obligations-to-report/"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 1000" src="/static/images/alltrials.png" alt="An AllTrials project"></a>


### PR DESCRIPTION
So that we can track IE11 users in a privacy-friendly way.