### PR TITLE
Update process_data.py

### DIFF
--- a/clinicaltrials/frontend/management/commands/process_data.py
+++ b/clinicaltrials/frontend/management/commands/process_data.py
@@ -35,7 +35,7 @@ def set_qa_metadata(trial):
 
     """
     registry_id = trial.registry_id
-    url = "https://clinicaltrials.gov/ct2/show/results/{}".format(registry_id)
+    url = "https://classic.clinicaltrials.gov/ct2/show/results/{}".format(registry_id)
     content = html.fromstring(requests.get(url).text)
     table = content.xpath("//table[.//th//text()[contains(., 'Submission Cycle')]]")
     results = content.xpath('//*[@id="results"]/text()')


### PR DESCRIPTION
Changed the `clinicaltrials.gov` url for the scraper to `classic.clinicaltrials.gov` to account for the website switch. This should be a quick fix to #256

I'm not sure if there are additional tests that might need to be adjusted as well but as far as functionality, I'm pretty sure this is the only thing that needs to change.