### PR TITLE
Revert "Add notification banner to base template"

### DIFF
--- a/clinicaltrials/static/scss/site.scss
+++ b/clinicaltrials/static/scss/site.scss
@@ -963,31 +963,3 @@ table.prelaunch td {
 #hidden-filter {
   visibility: hidden;
 }
-
-#notifyBanner {
-  background: #002147;
-  color: white;
-  display: block;
-  padding: 1rem;
-  text-align: center;
-  width: 100%;
-
-  p {
-    font-size: 1.1em;
-    margin: 0;
-  }
-
-  p:not(:last-child) {
-    margin-block-end: 1rem;
-  }
-
-  a {
-    color: white;
-    font-weight: 700;
-
-    &:where(:hover, :focus) {
-      color: rgba(255, 255, 255, 0.9);
-      text-decoration: none;
-    }
-  }
-}

--- a/clinicaltrials/templates/_base.html
+++ b/clinicaltrials/templates/_base.html
@@ -34,12 +34,6 @@
 </head>
 <body>
 <a target="_new" href="http://www.alltrials.net/find-out-more/why-this-matters/obligations-to-report/"><img style="position: absolute; top: 0; right: 0; border: 0; z-index: 1000" src="/static/images/alltrials.png" alt="An AllTrials project"></a>
-
-<section id="notifyBanner">
-  <p>Updates are currently paused as we adjust our code to account for the launch of <a href="https://www.clinicaltrials.gov/">the new ClinicalTrials.gov website</a>.</p>
-  <p>We hope to resume regular updates soon.</p>
-</section>
-
 <div class="wrapper">
 
     <div class="main-panel">


### PR DESCRIPTION
Reverts ebmdatalab/clinicaltrials-act-tracker#259
Tracker has been temporarily fixed by deploying https://github.com/ebmdatalab/clinicaltrials-act-tracker/pull/257